### PR TITLE
Allowing grid to start at non-zero value.

### DIFF
--- a/src/quantize.jl
+++ b/src/quantize.jl
@@ -4,8 +4,8 @@ export isgrid, classify, quantize, quantize!, quantize_duration!
 ###############################################################################
 function isgrid(grid)
     issorted(grid) || throw(ArgumentError("Grids must be sorted."))
-    if grid[1] != 0 || grid[end] != 1
-        throw(ArgumentError("Grids must start from 0 and end in 1."))
+    if abs(grid[1] - grid[end]) != 1 
+        throw(ArgumentError("Grids must start from x and end in 1+x."))
     end
     true
 end


### PR DESCRIPTION
I change line 7 to : 
```   
 if abs(grid[1] - grid[end]) != 1 
```
The drawback of this approach is that one has to explicitely write a grid of the form [x,...,1+x], the advantage is that the code doesn't need to be otherwise modified and therefore works as smoothly as before.