### PR TITLE
Implement `segmenting` option in `timeseries`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# 1.2.0
+* New function `segment(notes)`.
+* New option `segmented` in `timeseries`.
+
 # 1.1.0
 * New functions `timesort!` and `combine`.
 # 1.0.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MusicManipulations"
 uuid = "274955c0-c284-5bf7-b122-5ecd51c559de"
 repo = "https://github.com/JuliaMusic/MusicManipulations.jl.git"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 MIDI = "f57c4921-e30c-5f49-b073-3f2f2ada663e"

--- a/src/data_handling/timeseries.jl
+++ b/src/data_handling/timeseries.jl
@@ -58,11 +58,10 @@ end
 Quantizes the positions and durations of `notes` and segments them according to the duration of a grid unit.
 """
 function segment_notes(notes, grid)
-    tpq = notes.tpq
-    segment_duration = Int(grid[2]*tpq)
-    grid_division = Int(tpq/segment_duration)
+    segment_duration = Int(grid[2]*notes.tpq)
+    grid_division = Int(notes.tpq/segment_duration)
     qnotes = quantize(notes, 0:1//grid_division:1)
-    segmented_notes = Notes()
+    segmented_notes = Notes(;tpq = notes.tpq)
     for qn in qnotes
         for segment_idx in 0:round(Int,qn.duration/segment_duration)-1
             push!(segmented_notes, Note(qn.pitch, qn.velocity, qn.position + segment_idx*segment_duration, segment_duration))

--- a/src/data_handling/timeseries.jl
+++ b/src/data_handling/timeseries.jl
@@ -24,9 +24,6 @@ in order to respect the information of their duration. otherwise the notes are t
 """
 function timeseries(notes, property, f, grid; segmenting = false)
     isgrid(grid)
-    if segmenting == true
-        notes = timesort!(segment_notes(notes, grid))
-    end
     if !issorted(notes, by = x -> x.position)
         error("notes must be sorted by position!")
     elseif !isnothing(property) &&
@@ -67,7 +64,7 @@ function segment_notes(notes, grid)
             push!(segmented_notes, Note(qn.pitch, qn.velocity, qn.position + segment_idx*segment_duration, segment_duration))
         end
     end
-    return segmented_notes
+    return timesort!(segmented_notes)
 end
 
 """

--- a/src/data_handling/timeseries.jl
+++ b/src/data_handling/timeseries.jl
@@ -24,6 +24,9 @@ in order to respect the information of their duration. otherwise the notes are t
 """
 function timeseries(notes, property, f, grid; segmenting = false)
     isgrid(grid)
+    if segmenting == true
+        notes = segment_notes(notes, grid)
+    end
     if !issorted(notes, by = x -> x.position)
         error("notes must be sorted by position!")
     elseif !isnothing(property) &&

--- a/test/timeseries.jl
+++ b/test/timeseries.jl
@@ -134,11 +134,19 @@ end
     @test ts1 != ts2
 end
 
-#test of segmenting functionality
-notes_to_segment = Notes()
-push!(notes_to_segment,Note(67,70,15,540))
-push!(notes_to_segment,Note(70,75,330,125))
-push!(notes_to_segment,Note(60,73,610,829))
-tvec, ts = timeseries(notes_to_segment, :pitch, maximum, 0:1//6:1; segmenting = true)
-ts[findall(ismissing,ts)] .= 0
-@test ts == [67.0, 67.0, 70.0, 0.0, 60.0, 60.0, 60.0, 60.0, 60.0, 0.0, 0.0, 0.0]
+@testset "Segmentation" begin
+    #test of segmenting functionality
+    notes_to_segment = Notes()
+    push!(notes_to_segment,Note(67,70,15,540))
+    push!(notes_to_segment,Note(70,75,330,125))
+    push!(notes_to_segment,Note(60,73,610,829))
+    tvec, ts = timeseries(notes_to_segment, :pitch, maximum, 0:1//6:1; segmented = true)
+    ts[findall(ismissing,ts)] .= 0 # replace missing with zeros
+    @test ts == [67.0, 67.0, 70.0, 0.0, 60.0, 60.0, 60.0, 60.0, 60.0, 0.0, 0.0, 0.0]
+
+    dumnotes = Notes([Note(5, 5, 0, 960)])
+    snotes = segment(dumnotes, 0:1//4:1)
+    @test all(n -> n.duration == 240, snotes)
+    @test all(n -> n.velocity == 5, snotes)
+    @test length(snotes) == 4
+end

--- a/test/timeseries.jl
+++ b/test/timeseries.jl
@@ -133,3 +133,12 @@ end
     @test tvec1 == tvec2
     @test ts1 != ts2
 end
+
+#test of segmenting functionality
+notes_to_segment = Notes()
+push!(notes_to_segment,Note(67,70,15,540))
+push!(notes_to_segment,Note(70,75,330,125))
+push!(notes_to_segment,Note(60,73,610,829))
+tvec, ts = timeseries(notes_to_segment, :pitch, maximum, 0:1//6:1; segmenting = true)
+ts[findall(ismissing,ts)] .= 0
+@test ts == [67.0, 67.0, 70.0, 0.0, 60.0, 60.0, 60.0, 60.0, 60.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
I added a function `segment_notes` which takes notes and a grid in input, qantize them and segments them.
That way, we can plug this function in the `timeseries` function to keep its original implementation and avoid having to rewrite everything from scratch.
Everything that has to do with overlaps has been removed, since it can be done with the `f` argument of `timeseries` anyways.