### PR TITLE
extend translate and co

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+# 1.3.0
+* `translate, transpose, louden` now also work on single notes.
 
 # 1.2.0
 * New function `segment(notes)`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MusicManipulations"
 uuid = "274955c0-c284-5bf7-b122-5ecd51c559de"
 repo = "https://github.com/JuliaMusic/MusicManipulations.jl.git"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 MIDI = "f57c4921-e30c-5f49-b073-3f2f2ada663e"

--- a/src/general.jl
+++ b/src/general.jl
@@ -31,10 +31,13 @@ end
 """
     translate(notes, ticks)
 Translate the `notes` for the given amount of `ticks`.
+Also works for a single note.
 """
 translate(notes::Notes, ticks) = Notes(translate(notes.notes, ticks), notes.tpq)
 translate(notes::Vector{N}, ticks) where {N<:AbstractNote} =
 [N(n.pitch, n.velocity, n.position + ticks, n.duration, n.channel) for n in notes]
+translate(n::N, ticks) where {N<:AbstractNote} =
+N(n.pitch, n.velocity, n.position+ticks, n.duration, n.channel)
 
 """
     translate!(notes, ticks)
@@ -49,20 +52,26 @@ end
 """
     transpose(notes, semitones)
 Transpose the `notes` by the given amount of `semitones`.
+Also works for a single note.
 """
 Base.transpose(notes::Notes, semitones) =
 Notes(transpose(notes.notes, semitones), notes.tpq)
 Base.transpose(notes::Vector{N}, semitones) where {N<:AbstractNote} =
 [Note(n.pitch + semitones, n.velocity, n.position, n.duration, n.channel) for n in notes]
+Base.transpose(n::N, ticks) where {N<:AbstractNote} =
+N(n.pitch+ticks, n.velocity, n.position, n.duration, n.channel)
 
 """
     louden(notes, v::Int)
-Change the velocity of the notes by `v`.
+Change the velocity of the notes by `v` (which could also be negative).
+Also works for a single note.
 """
 louden(notes::Notes, v) =
 Notes(louden(notes.notes, v), notes.tpq)
 louden(notes::Vector{N}, v) where {N<:AbstractNote} =
 [Note(n.pitch, n.velocity + v, n.position, n.duration, n.channel) for n in notes]
+Base.louden(n::N, ticks) where {N<:AbstractNote} =
+N(n.pitch, n.velocity+ticks, n.position, n.duration, n.channel)
 
 """
     timesort!(notes::Notes)


### PR DESCRIPTION
Allows `translate/transpose/louden` to also act on a single note. Convenient for exercise generation.