### PR TITLE
Allow segmenting without explicit function input

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MusicManipulations"
 uuid = "274955c0-c284-5bf7-b122-5ecd51c559de"
 repo = "https://github.com/JuliaMusic/MusicManipulations.jl.git"
-version = "1.6.0"
+version = "1.6.01"
 
 [deps]
 ARFIMA = "9d0fb3db-ba49-4108-bc86-650b3813b6d5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MusicManipulations"
 uuid = "274955c0-c284-5bf7-b122-5ecd51c559de"
 repo = "https://github.com/JuliaMusic/MusicManipulations.jl.git"
-version = "1.6.01"
+version = "1.6.1"
 
 [deps]
 ARFIMA = "9d0fb3db-ba49-4108-bc86-650b3813b6d5"

--- a/src/data_handling/timeseries.jl
+++ b/src/data_handling/timeseries.jl
@@ -82,7 +82,7 @@ and output a numeric value. This is useful for example in cases where one
 would want the timeseries of the velocities of the notes of the
 highest pitch.
 """
-timeseries(notes, f, grid) = timeseries(notes, nothing, f, grid)
+timeseries(notes, f, grid; segmented = false) = timeseries(notes, nothing, f, grid; segmented = false)
 
 function produce_note_value(notes, property::Symbol, f, i, j)
     if j > 1


### PR DESCRIPTION
Segmenting is not permitted when calling ```timeseries(notes::Notes, f, grid)``` so far, but it would be good to be able to do it there as well.